### PR TITLE
Add auth wrappers and refactor server actions

### DIFF
--- a/app/actions/_secretActions.ts
+++ b/app/actions/_secretActions.ts
@@ -1,7 +1,7 @@
 "use server";
 
-import { currentUser } from "@clerk/nextjs/server";
 import type { Secret } from "@/generated/prisma";
+import { withAuth, withVaultAccess, withSecretAccess } from "@/lib/auth";
 import { AuthError } from "@/lib/errors";
 import { prisma } from "@/lib/prisma";
 import { isValidUUID } from "@/lib/uuid";
@@ -17,219 +17,125 @@ export interface UpdateSecretServerInput {
   encryptedData?: string;
 }
 
-export async function createSecret({
-  vaultId,
-  title,
-  encryptedData,
-}: CreateSecretServerInput): Promise<Secret> {
-  const user = await currentUser();
+export const createSecret = withVaultAccess(
+  async (_ctx, input: CreateSecretServerInput): Promise<Secret> => {
+    const { vaultId, title, encryptedData } = input;
 
-  if (!user) {
-    throw new AuthError("You are not signed in.");
-  }
-
-  // Validate UUID format
-  if (!isValidUUID(vaultId)) {
-    throw new AuthError("Invalid vault ID format.");
-  }
-
-  try {
-    // Verify user owns the vault
-    const vault = await prisma.vault.findFirst({
-      where: {
-        id: vaultId,
-        userId: user.id,
-      },
-    });
-
-    if (!vault) {
-      throw new AuthError("Vault not found or access denied.");
-    }
-
-    // Create the secret with pre-encrypted data
-    const secret = await prisma.secret.create({
-      data: {
-        vaultId,
-        title,
-        encryptedData,
-      },
-    });
-
-    return secret;
-  } catch (error) {
-    if (error instanceof AuthError) {
-      throw error;
-    }
-    console.error("Create secret error:", error);
-    throw new AuthError("Failed to create secret. Please try again later.");
-  }
-}
-
-export async function getSecrets(vaultId: string): Promise<Secret[]> {
-  const user = await currentUser();
-
-  if (!user) {
-    throw new AuthError("You are not signed in.");
-  }
-
-  // Validate UUID format
-  if (!isValidUUID(vaultId)) {
-    throw new AuthError("Invalid vault ID format.");
-  }
-
-  try {
-    // Verify user owns the vault
-    const vault = await prisma.vault.findFirst({
-      where: {
-        id: vaultId,
-        userId: user.id,
-      },
-    });
-
-    if (!vault) {
-      throw new AuthError("Vault not found or access denied.");
-    }
-
-    // Get secrets for the vault
-    const secrets = await prisma.secret.findMany({
-      where: {
-        vaultId,
-      },
-      orderBy: {
-        createdAt: "desc",
-      },
-    });
-
-    return secrets;
-  } catch (error) {
-    if (error instanceof AuthError) {
-      throw error;
-    }
-    console.error("Get secrets error:", error);
-    throw new AuthError("Failed to get secrets. Please try again later.");
-  }
-}
-
-export async function getSecret(secretId: string): Promise<Secret | null> {
-  const user = await currentUser();
-
-  if (!user) {
-    throw new AuthError("You are not signed in.");
-  }
-
-  // Validate UUID format
-  if (!isValidUUID(secretId)) {
-    return null;
-  }
-
-  try {
-    // Get the secret and verify ownership through vault
-    const secret = await prisma.secret.findFirst({
-      where: {
-        id: secretId,
-        vault: {
-          userId: user.id,
+    try {
+      // Create the secret with pre-encrypted data
+      const secret = await prisma.secret.create({
+        data: {
+          vaultId,
+          title,
+          encryptedData,
         },
-      },
-    });
+      });
 
-    return secret;
-  } catch (error) {
-    if (error instanceof AuthError) {
-      throw error;
+      return secret;
+    } catch (error) {
+      if (error instanceof AuthError) {
+        throw error;
+      }
+      console.error("Create secret error:", error);
+      throw new AuthError("Failed to create secret. Please try again later.");
     }
-    console.error("Get secret error:", error);
-    throw new AuthError("Failed to get secret. Please try again later.");
   }
-}
+);
 
-export async function updateSecret({
-  secretId,
-  updates,
-}: {
-  secretId: string;
-  updates: UpdateSecretServerInput;
-}): Promise<Secret> {
-  const user = await currentUser();
-
-  if (!user) {
-    throw new AuthError("You are not signed in.");
-  }
-
-  // Validate UUID format
-  if (!isValidUUID(secretId)) {
-    throw new AuthError("Invalid secret ID format.");
-  }
-
-  try {
-    // Get the secret and verify ownership through vault
-    const secret = await prisma.secret.findFirst({
-      where: {
-        id: secretId,
-        vault: {
-          userId: user.id,
+export const getSecrets = withVaultAccess(
+  async (_ctx, vaultId: string): Promise<Secret[]> => {
+    try {
+      // Get secrets for the vault
+      const secrets = await prisma.secret.findMany({
+        where: {
+          vaultId,
         },
-      },
-      include: {
-        vault: true,
-      },
-    });
-
-    if (!secret) {
-      throw new AuthError("Secret not found or access denied.");
-    }
-
-    // Update the secret
-    const updatedSecret = await prisma.secret.update({
-      where: { id: secretId },
-      data: updates,
-    });
-
-    return updatedSecret;
-  } catch (error) {
-    if (error instanceof AuthError) {
-      throw error;
-    }
-    console.error("Update secret error:", error);
-    throw new AuthError("Failed to update secret. Please try again later.");
-  }
-}
-
-export async function deleteSecret(secretId: string): Promise<void> {
-  const user = await currentUser();
-
-  if (!user) {
-    throw new AuthError("You are not signed in.");
-  }
-
-  // Validate UUID format
-  if (!isValidUUID(secretId)) {
-    throw new AuthError("Invalid secret ID format.");
-  }
-
-  try {
-    // Verify user owns the secret through vault ownership
-    const secret = await prisma.secret.findFirst({
-      where: {
-        id: secretId,
-        vault: {
-          userId: user.id,
+        orderBy: {
+          createdAt: "desc",
         },
-      },
-    });
+      });
 
-    if (!secret) {
-      throw new AuthError("Secret not found or access denied.");
+      return secrets;
+    } catch (error) {
+      if (error instanceof AuthError) {
+        throw error;
+      }
+      console.error("Get secrets error:", error);
+      throw new AuthError("Failed to get secrets. Please try again later.");
     }
-
-    await prisma.secret.delete({
-      where: { id: secretId },
-    });
-  } catch (error) {
-    if (error instanceof AuthError) {
-      throw error;
-    }
-    console.error("Delete secret error:", error);
-    throw new AuthError("Failed to delete secret. Please try again later.");
   }
-}
+);
+
+export const getSecret = withAuth(
+  async (user, secretId: string): Promise<Secret | null> => {
+    // Validate UUID format
+    if (!isValidUUID(secretId)) {
+      return null;
+    }
+
+    try {
+      // Get the secret and verify ownership through vault
+      const secret = await prisma.secret.findFirst({
+        where: {
+          id: secretId,
+          vault: {
+            userId: user.id,
+          },
+        },
+      });
+
+      return secret;
+    } catch (error) {
+      if (error instanceof AuthError) {
+        throw error;
+      }
+      console.error("Get secret error:", error);
+      throw new AuthError("Failed to get secret. Please try again later.");
+    }
+  }
+);
+
+export const updateSecret = withSecretAccess(
+  async (
+    _ctx,
+    {
+      secretId,
+      updates,
+    }: {
+      secretId: string;
+      updates: UpdateSecretServerInput;
+    }
+  ): Promise<Secret> => {
+    try {
+      // Update the secret
+      const updatedSecret = await prisma.secret.update({
+        where: { id: secretId },
+        data: updates,
+      });
+
+      return updatedSecret;
+    } catch (error) {
+      if (error instanceof AuthError) {
+        throw error;
+      }
+      console.error("Update secret error:", error);
+      throw new AuthError("Failed to update secret. Please try again later.");
+    }
+  }
+);
+
+export const deleteSecret = withSecretAccess(
+  async (_ctx, secretId: string): Promise<void> => {
+    try {
+      await prisma.secret.delete({
+        where: { id: secretId },
+      });
+    } catch (error) {
+      if (error instanceof AuthError) {
+        throw error;
+      }
+      console.error("Delete secret error:", error);
+      throw new AuthError("Failed to delete secret. Please try again later.");
+    }
+  }
+);

--- a/app/actions/_userActions.ts
+++ b/app/actions/_userActions.ts
@@ -1,74 +1,71 @@
 "use server";
 
-import { clerkClient, currentUser } from "@clerk/nextjs/server";
+import { clerkClient } from "@clerk/nextjs/server";
+import { withAuth } from "@/lib/auth";
 import { AuthError } from "@/lib/errors";
 import { prisma } from "@/lib/prisma";
 
-export async function finishOnboarding(data: {
-  salt: string;
-  publicKey: string;
-  wrappedPrivateKey: string;
-}) {
-  const client = await clerkClient();
-  const user = await currentUser();
+export const finishOnboarding = withAuth(
+  async (
+    user,
+    data: {
+      salt: string;
+      publicKey: string;
+      wrappedPrivateKey: string;
+    }
+  ) => {
+    const client = await clerkClient();
 
-  if (!user) {
-    throw new AuthError("You are not signed in.");
-  }
+    // TODO: handle user without primary email correctly
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const email = user.primaryEmailAddress!.emailAddress;
 
-  // TODO: handle user without primary email correctly
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  const email = user.primaryEmailAddress!.emailAddress;
+    const { salt, publicKey, wrappedPrivateKey } = data;
 
-  const { salt, publicKey, wrappedPrivateKey } = data;
+    try {
+      // Check if user already exists
+      const existingUser = await prisma.user.findUnique({
+        where: { id: user.id },
+      });
 
-  try {
-    // Check if user already exists
-    const existingUser = await prisma.user.findUnique({
-      where: { id: user.id },
-    });
+      if (existingUser) {
+        await client.users.updateUser(user.id, {
+          publicMetadata: {
+            onboardingComplete: true,
+          },
+        });
+        return;
+      }
 
-    if (existingUser) {
+      // Persist the new user
+      await prisma.user.create({
+        data: {
+          id: user.id,
+          email,
+          salt,
+          publicKey,
+          wrappedPrivateKey,
+        },
+      });
+
       await client.users.updateUser(user.id, {
         publicMetadata: {
           onboardingComplete: true,
         },
       });
-      return;
+    } catch (error) {
+      if (error instanceof AuthError) {
+        throw error;
+      }
+      console.error("Finish onboarding error:", error);
+      throw new AuthError(
+        "Failed to finish onboarding. Please try again later."
+      );
     }
-
-    // Persist the new user
-    await prisma.user.create({
-      data: {
-        id: user.id,
-        email,
-        salt,
-        publicKey,
-        wrappedPrivateKey,
-      },
-    });
-
-    await client.users.updateUser(user.id, {
-      publicMetadata: {
-        onboardingComplete: true,
-      },
-    });
-  } catch (error) {
-    if (error instanceof AuthError) {
-      throw error;
-    }
-    console.error("Finish onboarding error:", error);
-    throw new AuthError("Failed to finish onboarding. Please try again later.");
   }
-}
+);
 
-export async function getUserData() {
-  const user = await currentUser();
-
-  if (!user) {
-    throw new AuthError("You are not signed in.");
-  }
-
+export const getUserData = withAuth(async user => {
   const userData = await prisma.user.findUnique({
     where: { id: user.id },
     select: {
@@ -83,4 +80,4 @@ export async function getUserData() {
   }
 
   return userData;
-}
+});

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,0 +1,91 @@
+import type { User } from "@clerk/backend";
+import { currentUser } from "@clerk/nextjs/server";
+import type { Secret, Vault } from "@/generated/prisma";
+import { AuthError } from "./errors";
+import { prisma } from "./prisma";
+import { isValidUUID } from "./uuid";
+
+export async function requireUser(): Promise<User> {
+  const user = await currentUser();
+  if (!user) {
+    throw new AuthError("You are not signed in.");
+  }
+  return user;
+}
+
+export async function requireVaultAccess(
+  vaultId: string
+): Promise<{ user: User; vault: Vault }> {
+  const user = await requireUser();
+
+  if (!isValidUUID(vaultId)) {
+    throw new AuthError("Invalid vault ID format.");
+  }
+
+  const vault = await prisma.vault.findFirst({
+    where: {
+      id: vaultId,
+      userId: user.id,
+    },
+  });
+
+  if (!vault) {
+    throw new AuthError("Vault not found or access denied.");
+  }
+
+  return { user, vault };
+}
+
+export async function requireSecretAccess(
+  secretId: string
+): Promise<{ user: User; secret: Secret }> {
+  const user = await requireUser();
+
+  if (!isValidUUID(secretId)) {
+    throw new AuthError("Invalid secret ID format.");
+  }
+
+  const secret = await prisma.secret.findFirst({
+    where: {
+      id: secretId,
+      vault: {
+        userId: user.id,
+      },
+    },
+  });
+
+  if (!secret) {
+    throw new AuthError("Secret not found or access denied.");
+  }
+
+  return { user, secret };
+}
+
+export function withAuth<A extends unknown[], R>(
+  fn: (user: User, ...args: A) => Promise<R> | R
+): (...args: A) => Promise<R> {
+  return async (...args: A) => {
+    const user = await requireUser();
+    return fn(user, ...args);
+  };
+}
+
+export function withVaultAccess<T extends { vaultId: string } | string, R>(
+  fn: (context: { user: User; vault: Vault }, input: T) => Promise<R> | R
+): (input: T) => Promise<R> {
+  return async (input: T) => {
+    const vaultId = typeof input === "string" ? input : input.vaultId;
+    const context = await requireVaultAccess(vaultId);
+    return fn(context, input);
+  };
+}
+
+export function withSecretAccess<T extends { secretId: string } | string, R>(
+  fn: (context: { user: User; secret: Secret }, input: T) => Promise<R> | R
+): (input: T) => Promise<R> {
+  return async (input: T) => {
+    const secretId = typeof input === "string" ? input : input.secretId;
+    const context = await requireSecretAccess(secretId);
+    return fn(context, input);
+  };
+}


### PR DESCRIPTION
## Summary
- implement `withAuth`, `withVaultAccess`, and `withSecretAccess` wrapper helpers
- refactor user, vault, and secret actions to use the new wrappers

## Testing
- `npm run format`
- `npm run lint`
- `npm run type-check`
