### PR TITLE
Add auth wrappers and refactor server actions

### DIFF
--- a/app/actions/_secretActions.ts
+++ b/app/actions/_secretActions.ts
@@ -2,105 +2,127 @@
 
 import type { Secret } from "@/generated/prisma";
 import { withVaultAccess, withSecretAccess } from "@/lib/auth";
-import { AuthError } from "@/lib/errors";
+import { AppError, ErrorCode, withErrorHandling } from "@/lib/errors";
 import { prisma } from "@/lib/prisma";
 
-export const createSecret = withVaultAccess(
-  async (
-    ctx,
-    input: { title: string; encryptedData: string }
-  ): Promise<Secret> => {
-    const { title, encryptedData } = input;
+export const createSecret = withErrorHandling(
+  withVaultAccess(
+    async (
+      ctx,
+      input: { title: string; encryptedData: string }
+    ): Promise<Secret> => {
+      const { title, encryptedData } = input;
 
+      try {
+        // Create the secret with pre-encrypted data
+        const secret = await prisma.secret.create({
+          data: {
+            vaultId: ctx.vault.id,
+            title,
+            encryptedData,
+          },
+        });
+
+        return secret;
+      } catch (error) {
+        if (error instanceof AppError) {
+          throw error;
+        }
+        console.error("Create secret error:", error);
+        throw new AppError(
+          "Failed to create secret. Please try again later.",
+          ErrorCode.DATABASE_ERROR
+        );
+      }
+    }
+  )
+);
+
+export const getSecrets = withErrorHandling(
+  withVaultAccess(async (ctx): Promise<Secret[]> => {
     try {
-      // Create the secret with pre-encrypted data
-      const secret = await prisma.secret.create({
-        data: {
+      // Get secrets for the vault
+      const secrets = await prisma.secret.findMany({
+        where: {
           vaultId: ctx.vault.id,
-          title,
-          encryptedData,
+        },
+        orderBy: {
+          createdAt: "desc",
         },
       });
 
-      return secret;
+      return secrets;
     } catch (error) {
-      if (error instanceof AuthError) {
+      if (error instanceof AppError) {
         throw error;
       }
-      console.error("Create secret error:", error);
-      throw new AuthError("Failed to create secret. Please try again later.");
+      console.error("Get secrets error:", error);
+      throw new AppError(
+        "Failed to get secrets. Please try again later.",
+        ErrorCode.DATABASE_ERROR
+      );
     }
-  }
+  })
 );
 
-export const getSecrets = withVaultAccess(async (ctx): Promise<Secret[]> => {
-  try {
-    // Get secrets for the vault
-    const secrets = await prisma.secret.findMany({
-      where: {
-        vaultId: ctx.vault.id,
-      },
-      orderBy: {
-        createdAt: "desc",
-      },
-    });
-
-    return secrets;
-  } catch (error) {
-    if (error instanceof AuthError) {
-      throw error;
-    }
-    console.error("Get secrets error:", error);
-    throw new AuthError("Failed to get secrets. Please try again later.");
-  }
-});
-
-export const getSecret = withSecretAccess(async (ctx): Promise<Secret> => {
-  return ctx.secret;
-});
+export const getSecret = withErrorHandling(
+  withSecretAccess(async (ctx): Promise<Secret> => {
+    return ctx.secret;
+  })
+);
 
 export interface UpdateSecretServerInput {
   title?: string;
   encryptedData?: string;
 }
 
-export const updateSecret = withSecretAccess(
-  async (
-    ctx,
-    {
-      updates,
-    }: {
-      updates: UpdateSecretServerInput;
-    }
-  ): Promise<Secret> => {
-    try {
-      // Update the secret
-      const updatedSecret = await prisma.secret.update({
-        where: { id: ctx.secret.id },
-        data: updates,
-      });
-
-      return updatedSecret;
-    } catch (error) {
-      if (error instanceof AuthError) {
-        throw error;
+export const updateSecret = withErrorHandling(
+  withSecretAccess(
+    async (
+      ctx,
+      {
+        updates,
+      }: {
+        updates: UpdateSecretServerInput;
       }
-      console.error("Update secret error:", error);
-      throw new AuthError("Failed to update secret. Please try again later.");
+    ): Promise<Secret> => {
+      try {
+        // Update the secret
+        const updatedSecret = await prisma.secret.update({
+          where: { id: ctx.secret.id },
+          data: updates,
+        });
+
+        return updatedSecret;
+      } catch (error) {
+        if (error instanceof AppError) {
+          throw error;
+        }
+        console.error("Update secret error:", error);
+        throw new AppError(
+          "Failed to update secret. Please try again later.",
+          ErrorCode.DATABASE_ERROR
+        );
+      }
     }
-  }
+  )
 );
 
-export const deleteSecret = withSecretAccess(async (ctx): Promise<void> => {
-  try {
-    await prisma.secret.delete({
-      where: { id: ctx.secret.id },
-    });
-  } catch (error) {
-    if (error instanceof AuthError) {
-      throw error;
+export const deleteSecret = withErrorHandling(
+  withSecretAccess(async (ctx): Promise<void> => {
+    try {
+      await prisma.secret.delete({
+        where: { id: ctx.secret.id },
+      });
+    } catch (error) {
+      if (error instanceof AppError) {
+        throw error;
+      }
+      console.error("Delete secret error:", error);
+      throw new AppError(
+        "Failed to delete secret. Please try again later.",
+        ErrorCode.DATABASE_ERROR
+      );
     }
-    console.error("Delete secret error:", error);
-    throw new AuthError("Failed to delete secret. Please try again later.");
-  }
-});
+  })
+);

--- a/app/actions/_userActions.ts
+++ b/app/actions/_userActions.ts
@@ -2,82 +2,92 @@
 
 import { clerkClient } from "@clerk/nextjs/server";
 import { withAuth } from "@/lib/auth";
-import { AuthError } from "@/lib/errors";
+import {
+  AppError,
+  ErrorCode,
+  withErrorHandling,
+  NotFoundError,
+} from "@/lib/errors";
 import { prisma } from "@/lib/prisma";
 
-export const finishOnboarding = withAuth(
-  async (
-    { user },
-    data: {
-      salt: string;
-      publicKey: string;
-      wrappedPrivateKey: string;
-    }
-  ) => {
-    const client = await clerkClient();
+export const finishOnboarding = withErrorHandling(
+  withAuth(
+    async (
+      { user },
+      data: {
+        salt: string;
+        publicKey: string;
+        wrappedPrivateKey: string;
+      }
+    ) => {
+      const client = await clerkClient();
 
-    // TODO: handle user without primary email correctly
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    const email = user.primaryEmailAddress!.emailAddress;
+      // TODO: handle user without primary email correctly
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const email = user.primaryEmailAddress!.emailAddress;
 
-    const { salt, publicKey, wrappedPrivateKey } = data;
+      const { salt, publicKey, wrappedPrivateKey } = data;
 
-    try {
-      // Check if user already exists
-      const existingUser = await prisma.user.findUnique({
-        where: { id: user.id },
-      });
+      try {
+        // Check if user already exists
+        const existingUser = await prisma.user.findUnique({
+          where: { id: user.id },
+        });
 
-      if (existingUser) {
+        if (existingUser) {
+          await client.users.updateUser(user.id, {
+            publicMetadata: {
+              onboardingComplete: true,
+            },
+          });
+          return;
+        }
+
+        // Persist the new user
+        await prisma.user.create({
+          data: {
+            id: user.id,
+            email,
+            salt,
+            publicKey,
+            wrappedPrivateKey,
+          },
+        });
+
         await client.users.updateUser(user.id, {
           publicMetadata: {
             onboardingComplete: true,
           },
         });
-        return;
+      } catch (error) {
+        if (error instanceof AppError) {
+          throw error;
+        }
+        console.error("Finish onboarding error:", error);
+        throw new AppError(
+          "Failed to finish onboarding. Please try again later.",
+          ErrorCode.ONBOARDING_FAILED
+        );
       }
-
-      // Persist the new user
-      await prisma.user.create({
-        data: {
-          id: user.id,
-          email,
-          salt,
-          publicKey,
-          wrappedPrivateKey,
-        },
-      });
-
-      await client.users.updateUser(user.id, {
-        publicMetadata: {
-          onboardingComplete: true,
-        },
-      });
-    } catch (error) {
-      if (error instanceof AuthError) {
-        throw error;
-      }
-      console.error("Finish onboarding error:", error);
-      throw new AuthError(
-        "Failed to finish onboarding. Please try again later."
-      );
     }
-  }
+  )
 );
 
-export const getUserData = withAuth(async ({ user }) => {
-  const userData = await prisma.user.findUnique({
-    where: { id: user.id },
-    select: {
-      salt: true,
-      wrappedPrivateKey: true,
-      publicKey: true,
-    },
-  });
+export const getUserData = withErrorHandling(
+  withAuth(async ({ user }) => {
+    const userData = await prisma.user.findUnique({
+      where: { id: user.id },
+      select: {
+        salt: true,
+        wrappedPrivateKey: true,
+        publicKey: true,
+      },
+    });
 
-  if (!userData) {
-    throw new AuthError("User data not found.");
-  }
+    if (!userData) {
+      throw new NotFoundError("User data not found.", ErrorCode.NOT_FOUND);
+    }
 
-  return userData;
-});
+    return userData;
+  })
+);

--- a/app/actions/_vaultActions.ts
+++ b/app/actions/_vaultActions.ts
@@ -2,55 +2,67 @@
 
 import type { Vault } from "@/generated/prisma";
 import { withAuth, withVaultAccess } from "@/lib/auth";
-import { AuthError } from "@/lib/errors";
+import { AppError, ErrorCode, withErrorHandling } from "@/lib/errors";
 import { prisma } from "@/lib/prisma";
 
-export const createVault = withAuth(
-  async (
-    { user },
-    {
-      name,
-      wrappedKey,
-    }: {
-      name: string;
-      wrappedKey: string;
+export const createVault = withErrorHandling(
+  withAuth(
+    async (
+      { user },
+      {
+        name,
+        wrappedKey,
+      }: {
+        name: string;
+        wrappedKey: string;
+      }
+    ) => {
+      try {
+        await prisma.vault.create({
+          data: {
+            name,
+            wrappedKey,
+            userId: user.id,
+          },
+        });
+      } catch (error) {
+        if (error instanceof AppError) {
+          throw error;
+        }
+        console.error("Create vault error:", error);
+        throw new AppError(
+          "Failed to create vault. Please try again later.",
+          ErrorCode.DATABASE_ERROR
+        );
+      }
     }
-  ) => {
+  )
+);
+
+export const getVaults = withErrorHandling(
+  withAuth(async ({ user }) => {
     try {
-      await prisma.vault.create({
-        data: {
-          name,
-          wrappedKey,
+      const vaults = await prisma.vault.findMany({
+        where: {
           userId: user.id,
         },
       });
+      return vaults;
     } catch (error) {
-      if (error instanceof AuthError) {
+      if (error instanceof AppError) {
         throw error;
       }
-      console.error("Create vault error:", error);
-      throw new AuthError("Failed to create vault. Please try again later.");
+      console.error("Get vaults error:", error);
+      throw new AppError(
+        "Failed to get vaults. Please try again later.",
+        ErrorCode.DATABASE_ERROR
+      );
     }
-  }
+  })
 );
 
-export const getVaults = withAuth(async ({ user }) => {
-  try {
-    const vaults = await prisma.vault.findMany({
-      where: {
-        userId: user.id,
-      },
-    });
-    return vaults;
-  } catch (error) {
-    if (error instanceof AuthError) {
-      throw error;
-    }
-    console.error("Get vaults error:", error);
-    throw new AuthError("Failed to get vaults. Please try again later.");
-  }
-});
-
-export const getVault = withVaultAccess(async ({ vault }): Promise<Vault> => {
-  return vault;
-});
+export const getVault = withErrorHandling(
+  withVaultAccess(async ({ vault }): Promise<Vault> => {
+    return vault;
+  })
+);

--- a/app/app/[vaultId]/page.tsx
+++ b/app/app/[vaultId]/page.tsx
@@ -3,6 +3,7 @@ import { getVault } from "@/app/actions/_vaultActions";
 import { SecretFormDialog } from "@/components/secret-form-dialog";
 import { SecretsList } from "@/components/secrets-list";
 import { Button } from "@/components/ui/button";
+import { isErrorResponse } from "@/lib/query-utils";
 
 export default async function VaultPage({
   params,
@@ -10,9 +11,13 @@ export default async function VaultPage({
   params: Promise<{ vaultId: string }>;
 }) {
   const vaultId = (await params).vaultId;
-  const vault = await getVault({ vaultId });
+  const response = await getVault({ vaultId });
 
-  if (!vault) {
+  // Handle error responses
+  if (isErrorResponse(response)) {
+    const { error } = response;
+    console.error(`[${error.code}] Failed to load vault: ${error.message}`);
+
     return (
       <div className="flex min-h-[50vh] flex-col items-center justify-center space-y-4 p-6">
         <div className="bg-muted rounded-full p-4">
@@ -20,16 +25,21 @@ export default async function VaultPage({
         </div>
         <div className="space-y-2 text-center">
           <h2 className="text-foreground text-xl font-semibold">
-            Vault Not Found
+            {error.code === "NOT_FOUND"
+              ? "Vault Not Found"
+              : "Error Loading Vault"}
           </h2>
           <p className="text-muted-foreground">
-            The vault you&apos;re looking for doesn&apos;t exist or you
-            don&apos;t have access to it.
+            {error.code === "NOT_FOUND"
+              ? "The vault you're looking for doesn't exist or you don't have access to it."
+              : "Unable to load vault. Please try again later."}
           </p>
         </div>
       </div>
     );
   }
+
+  const vault = response.data;
 
   return (
     <div className="p-6">

--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -6,6 +6,7 @@ import {
   SidebarHeader,
   SidebarRail,
 } from "@/components/ui/sidebar";
+import { isErrorResponse } from "@/lib/query-utils";
 import { AccountMenu } from "./account-menu";
 import { SidebarAddVaultButton } from "./sidebar-add-vault-button";
 import { SidebarVaultList } from "./sidebar-vault-list";
@@ -18,7 +19,37 @@ export async function AppSidebar({
     return null;
   }
 
-  const vaults = await getVaults();
+  const response = await getVaults();
+
+  // Handle error responses
+  if (isErrorResponse(response)) {
+    const { error } = response;
+    console.error(`[${error.code}] Failed to load vaults: ${error.message}`);
+
+    // Return a fallback sidebar with limited functionality
+    return (
+      <Sidebar {...props}>
+        <SidebarHeader>
+          <AccountMenu
+            // TODO: handle edge cases where user data is not available
+            email={user.primaryEmailAddress?.emailAddress || ""}
+            fullName={user.fullName || ""}
+            imageUrl={user.imageUrl || ""}
+            initials={(user.firstName || "")[0] + (user.lastName || "")[0]}
+          />
+          <SidebarAddVaultButton />
+        </SidebarHeader>
+        <SidebarContent>
+          <div className="text-muted-foreground p-4 text-center text-sm">
+            Unable to load vaults. Please refresh the page.
+          </div>
+        </SidebarContent>
+        <SidebarRail />
+      </Sidebar>
+    );
+  }
+
+  const vaults = response.data;
 
   return (
     <Sidebar {...props}>

--- a/components/secrets-list.tsx
+++ b/components/secrets-list.tsx
@@ -159,11 +159,18 @@ function SecretsList({ vaultId }: SecretsListProps) {
                   </DropdownMenuItem>
                   <DropdownMenuItem
                     onClick={async () => {
-                      await secretsClient.deleteSecret(secret.id);
-                      await queryClient.invalidateQueries({
-                        queryKey: [SECRETS_LIST_QUERY_KEY, vaultId],
-                      });
-                      toast.success("Secret deleted");
+                      try {
+                        await secretsClient.deleteSecret(secret.id);
+                        await queryClient.invalidateQueries({
+                          queryKey: [SECRETS_LIST_QUERY_KEY, vaultId],
+                        });
+                        toast.success("Secret deleted");
+                      } catch (error) {
+                        console.error("Failed to delete secret:", error);
+                        toast.error(
+                          "Failed to delete secret. Please try again."
+                        );
+                      }
                     }}
                     variant="destructive"
                   >

--- a/components/sidebar-vault-list.tsx
+++ b/components/sidebar-vault-list.tsx
@@ -4,6 +4,7 @@ import { useQuery } from "@tanstack/react-query";
 import { useParams, useRouter } from "next/navigation";
 import { getVaults } from "@/app/actions/_vaultActions";
 import type { Vault } from "@/generated/prisma";
+import { handleActionResponse, getErrorInfo } from "@/lib/query-utils";
 import {
   SidebarGroup,
   SidebarGroupContent,
@@ -18,11 +19,58 @@ const SIDEBAR_VAULT_LIST_QUERY_KEY = "sidebar-vault-list";
 const SidebarVaultList = ({ vaults: initialVaults }: { vaults: Vault[] }) => {
   const { vaultId } = useParams();
   const router = useRouter();
-  const { data: vaults } = useQuery({
+  const { data: vaults, error } = useQuery({
     queryKey: [SIDEBAR_VAULT_LIST_QUERY_KEY],
-    queryFn: getVaults,
+    queryFn: async () => {
+      const response = await getVaults();
+      return handleActionResponse(response);
+    },
     initialData: initialVaults,
   });
+
+  // Handle query errors
+  if (error) {
+    const errorInfo = getErrorInfo(error);
+    console.error(
+      `[${errorInfo.code}] Failed to load vaults:`,
+      errorInfo.message
+    );
+
+    return (
+      <>
+        <SidebarGroup>
+          <SidebarGroupContent>
+            <SidebarMenu>
+              <SidebarMenuItem key="all-vaults">
+                <SidebarMenuButton
+                  isActive={vaultId === undefined}
+                  onClick={() => router.push(`/app`)}
+                >
+                  All Vaults
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+              <SidebarMenuItem key="favorites">
+                <SidebarMenuButton
+                  isActive={vaultId === "favorites"}
+                  onClick={() => router.push(`/app/favorites`)}
+                >
+                  Favorites
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
+        <SidebarGroup>
+          <SidebarGroupLabel>Vaults</SidebarGroupLabel>
+          <SidebarGroupContent>
+            <div className="text-muted-foreground p-2 text-center text-sm">
+              Unable to load vaults
+            </div>
+          </SidebarGroupContent>
+        </SidebarGroup>
+      </>
+    );
+  }
 
   return (
     <>

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -1,6 +1,122 @@
-export class AuthError extends Error {
-  constructor(message: string) {
+export enum ErrorCode {
+  // Authentication errors
+  UNAUTHORIZED = "UNAUTHORIZED",
+  FORBIDDEN = "FORBIDDEN",
+
+  // Validation errors
+  INVALID_INPUT = "INVALID_INPUT",
+  INVALID_UUID = "INVALID_UUID",
+
+  // Resource errors
+  NOT_FOUND = "NOT_FOUND",
+  ALREADY_EXISTS = "ALREADY_EXISTS",
+
+  // Server errors
+  INTERNAL_SERVER_ERROR = "INTERNAL_SERVER_ERROR",
+  DATABASE_ERROR = "DATABASE_ERROR",
+
+  // Action-specific errors
+  ONBOARDING_FAILED = "ONBOARDING_FAILED",
+}
+
+export interface ActionErrorResponse {
+  success: false;
+  error: {
+    code: ErrorCode;
+    message: string;
+    statusCode: number;
+  };
+}
+
+export interface ActionSuccessResponse<T = unknown> {
+  success: true;
+  data: T;
+}
+
+export type ActionResponse<T = unknown> =
+  | ActionSuccessResponse<T>
+  | ActionErrorResponse;
+
+export class AppError extends Error {
+  public readonly code: ErrorCode;
+  public readonly statusCode: number;
+
+  constructor(message: string, code: ErrorCode, statusCode: number = 500) {
     super(message);
+    this.name = "AppError";
+    this.code = code;
+    this.statusCode = statusCode;
+  }
+}
+
+export class AuthError extends AppError {
+  constructor(message: string, code: ErrorCode = ErrorCode.UNAUTHORIZED) {
+    const statusCode = code === ErrorCode.FORBIDDEN ? 403 : 401;
+    super(message, code, statusCode);
     this.name = "AuthError";
   }
+}
+
+export class ValidationError extends AppError {
+  constructor(message: string, code: ErrorCode = ErrorCode.INVALID_INPUT) {
+    super(message, code, 400);
+    this.name = "ValidationError";
+  }
+}
+
+export class NotFoundError extends AppError {
+  constructor(message: string, code: ErrorCode = ErrorCode.NOT_FOUND) {
+    super(message, code, 404);
+    this.name = "NotFoundError";
+  }
+}
+
+// Helper function to create error responses
+export function createErrorResponse(
+  error: AppError | Error,
+  fallbackCode: ErrorCode = ErrorCode.INTERNAL_SERVER_ERROR
+): ActionErrorResponse {
+  if (error instanceof AppError) {
+    return {
+      success: false,
+      error: {
+        code: error.code,
+        message: error.message,
+        statusCode: error.statusCode,
+      },
+    };
+  }
+
+  // Handle unknown errors
+  console.error("Unhandled error:", error);
+  return {
+    success: false,
+    error: {
+      code: fallbackCode,
+      message: "An unexpected error occurred. Please try again later.",
+      statusCode: 500,
+    },
+  };
+}
+
+// Helper function to create success responses
+export function createSuccessResponse<T>(data: T): ActionSuccessResponse<T> {
+  return {
+    success: true,
+    data,
+  };
+}
+
+// Higher-order function to wrap server actions with error handling
+export function withErrorHandling<TArgs extends unknown[], TReturn>(
+  action: (...args: TArgs) => Promise<TReturn>
+): (...args: TArgs) => Promise<ActionResponse<TReturn>> {
+  return async (...args: TArgs): Promise<ActionResponse<TReturn>> => {
+    try {
+      const result = await action(...args);
+      return createSuccessResponse(result);
+    } catch (error) {
+      return createErrorResponse(error as AppError | Error);
+    }
+  };
 }

--- a/lib/query-utils.ts
+++ b/lib/query-utils.ts
@@ -1,0 +1,56 @@
+import {
+  AppError,
+  type ActionResponse,
+  type ActionErrorResponse,
+} from "./errors";
+
+/**
+ * Helper function to handle server action responses in TanStack Query
+ * This function checks if the response is an error and throws it for proper error handling
+ */
+export function handleActionResponse<T>(response: ActionResponse<T>): T {
+  if (!response.success) {
+    // Create an error object that TanStack Query can handle
+    const error = new AppError(
+      response.error.message,
+      response.error.code,
+      response.error.statusCode
+    );
+
+    throw error;
+  }
+
+  return response.data;
+}
+
+/**
+ * Type guard to check if a response is an error response
+ */
+export function isErrorResponse<T>(
+  response: ActionResponse<T>
+): response is ActionErrorResponse {
+  return !response.success;
+}
+
+/**
+ * Helper to extract error information from a caught error in TanStack Query
+ */
+export function getErrorInfo(error: unknown): {
+  message: string;
+  code?: string;
+  statusCode?: number;
+} {
+  if (error instanceof Error) {
+    return {
+      message: error.message,
+      code: (error as AppError).code,
+      statusCode: (error as AppError).statusCode,
+    };
+  }
+
+  return {
+    message: "An unexpected error occurred",
+    code: "UNKNOWN_ERROR",
+    statusCode: 500,
+  };
+}


### PR DESCRIPTION
## Summary
- implement `withAuth`, `withVaultAccess`, and `withSecretAccess` wrapper helpers
- refactor user, vault, and secret actions to use the new wrappers

## Testing
- `npm run format`
- `npm run lint`
- `npm run type-check`
