### PR TITLE
implemented all secrets view

### DIFF
--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -1,18 +1,15 @@
 "use client";
 
-import { useKeyStore } from "@/context/KeyStore";
+import { AllSecretsList } from "@/components/secrets-list";
 
 export default function Page() {
-  const { isInitialized, privateKey, publicKey } = useKeyStore();
-
-  if (!isInitialized) {
-    return <p>Loading...</p>;
-  }
-
   return (
-    <div>
-      <p>Private Key: {JSON.stringify(privateKey.algorithm)}</p>
-      <p>Public Key: {JSON.stringify(publicKey.algorithm)}</p>
+    <div className="p-6">
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold">All Secrets</h1>
+      </div>
+
+      <AllSecretsList />
     </div>
   );
 }

--- a/components/sidebar-vault-list.tsx
+++ b/components/sidebar-vault-list.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { MoreVerticalIcon, UsersIcon } from "lucide-react";
+import { List, MoreVerticalIcon, UsersIcon } from "lucide-react";
 import { useParams, useRouter } from "next/navigation";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { deleteVault, getVaults } from "@/app/actions/_vaultActions";
 import { handleActionResponse, getErrorInfo } from "@/lib/query-utils";
 import { getRoleDisplayName } from "@/lib/utils";
@@ -151,6 +151,14 @@ const SidebarVaultList = ({
     placeholderData: initialVaults,
   });
 
+  const ownedVaults = useMemo(() => {
+    return vaults?.filter(vault => vault.isOwner);
+  }, [vaults]);
+
+  const sharedVaults = useMemo(() => {
+    return vaults?.filter(vault => !vault.isOwner);
+  }, [vaults]);
+
   // Handle query errors
   if (error) {
     const errorInfo = getErrorInfo(error);
@@ -169,15 +177,10 @@ const SidebarVaultList = ({
                   isActive={vaultId === undefined}
                   onClick={() => router.push(`/app`)}
                 >
-                  All Vaults
-                </SidebarMenuButton>
-              </SidebarMenuItem>
-              <SidebarMenuItem key="favorites">
-                <SidebarMenuButton
-                  isActive={vaultId === "favorites"}
-                  onClick={() => router.push(`/app/favorites`)}
-                >
-                  Favorites
+                  <div className="flex w-full items-center justify-between gap-2">
+                    <span>All Secrets</span>
+                    <List className="size-4" />
+                  </div>
                 </SidebarMenuButton>
               </SidebarMenuItem>
             </SidebarMenu>
@@ -205,15 +208,10 @@ const SidebarVaultList = ({
                 isActive={vaultId === undefined}
                 onClick={() => router.push(`/app`)}
               >
-                All Vaults
-              </SidebarMenuButton>
-            </SidebarMenuItem>
-            <SidebarMenuItem key="favorites">
-              <SidebarMenuButton
-                isActive={vaultId === "favorites"}
-                onClick={() => router.push(`/app/favorites`)}
-              >
-                Favorites
+                <div className="flex w-full items-center justify-between gap-2">
+                  <span>All Secrets</span>
+                  <List className="size-4" />
+                </div>
               </SidebarMenuButton>
             </SidebarMenuItem>
           </SidebarMenu>
@@ -223,18 +221,25 @@ const SidebarVaultList = ({
       <SidebarGroup>
         <SidebarGroupLabel>My Vaults</SidebarGroupLabel>
         <SidebarGroupContent>
-          <SidebarMenu>
-            {(vaults || [])
-              .filter(vault => vault.isOwner !== false)
-              .map(vault => (
+          {!ownedVaults || ownedVaults.length === 0 ? (
+            <div className="text-muted-foreground p-4 text-center text-sm">
+              <p className="font-medium">No vaults yet</p>
+              <p className="mt-1 text-xs">
+                Create your first vault to start storing secrets securely
+              </p>
+            </div>
+          ) : (
+            <SidebarMenu>
+              {ownedVaults.map(vault => (
                 <VaultItem key={vault.id} vault={vault} />
               ))}
-          </SidebarMenu>
+            </SidebarMenu>
+          )}
         </SidebarGroupContent>
       </SidebarGroup>
 
       {/* Shared Vaults */}
-      {vaults && vaults.some(vault => vault.isOwner === false) && (
+      {sharedVaults && sharedVaults.length > 0 && (
         <SidebarGroup>
           <SidebarGroupLabel>Shared With Me</SidebarGroupLabel>
           <SidebarGroupContent>

--- a/types/secret.ts
+++ b/types/secret.ts
@@ -25,3 +25,11 @@ export interface SecretWithDecryptedData {
   createdAt: Date;
   updatedAt: Date;
 }
+
+export interface SecretWithDecryptedDataAndVault
+  extends SecretWithDecryptedData {
+  vault: {
+    id: string;
+    name: string;
+  };
+}


### PR DESCRIPTION
This pull request introduces a new feature to display all secrets across vaults, along with several related enhancements and refactors. The key changes include adding a new API endpoint to fetch secrets with their associated vaults, creating a reusable base component for secrets lists, and updating the UI to support the new "All Secrets" view. Additionally, the sidebar now includes a clearer distinction between owned and shared vaults.

### Backend Enhancements:

* **New API Endpoint for Secrets with Vaults**:
  - Added the `getAllSecretsWithVaults` function in `app/actions/_secretActions.ts` to fetch secrets along with their associated vault details. This includes filtering by user access and limiting results to the latest 50 entries.
  - Updated `SecretsClient` in `lib/secrets-client.ts` to include `getAllSecretsWithDecryptedData`, which decrypts secrets and associates them with vault metadata.

* **New Type Definitions**:
  - Introduced `SecretWithDecryptedDataAndVault` in `types/secret.ts` to represent secrets with their vault information.

### Frontend Enhancements:

* **"All Secrets" View**:
  - Added a new `AllSecretsList` component as a wrapper for the reusable `SecretsListBase` component, which displays all secrets across vaults with vault badges for context.
  - Updated the main page (`app/app/page.tsx`) to use the `AllSecretsList` component, replacing the placeholder key display.

* **Reusable Secrets List Component**:
  - Refactored `SecretsList` into a base component, `SecretsListBase`, to support both vault-specific and "all-secrets" views. This includes handling permissions, vault badges, and empty state messages. [[1]](diffhunk://#diff-b94573df3c222829cbdc6b8607dfaf0d6b83d10d8ad2810ac211134d139b7badR37-R82) [[2]](diffhunk://#diff-b94573df3c222829cbdc6b8607dfaf0d6b83d10d8ad2810ac211134d139b7badR110-R159)

* **Improved Sidebar Vault Organization**:
  - Added `useMemo` hooks in `components/sidebar-vault-list.tsx` to separate owned and shared vaults.
  - Updated the sidebar to display a clearer distinction between "My Vaults" and "Shared With Me," with empty states for each section. [[1]](diffhunk://#diff-f6ec32b9b65a9f091c06b24d593006ba10fd04b45b62ca229b243574288f98a4R154-R161) [[2]](diffhunk://#diff-f6ec32b9b65a9f091c06b24d593006ba10fd04b45b62ca229b243574288f98a4R224-R242)

### UI Improvements:

* **Vault Badges in Secrets List**:
  - Added clickable badges to display vault names in the "All Secrets" view, allowing users to navigate to specific vaults.
  
* **Empty State Messages**:
  - Enhanced empty state messages for both vault-specific and "all-secrets" views to provide more context and guidance.

These changes collectively improve the user experience by introducing a centralized view of all secrets, enhancing the flexibility of the secrets list component, and refining the sidebar organization.